### PR TITLE
feat: 기도카드 만들기 기능 구현

### DIFF
--- a/src/components/Group.jsx
+++ b/src/components/Group.jsx
@@ -56,6 +56,7 @@ const Group = () => {
           isOpen={isModalOpen}
           onClose={closeModal}
           member={selectedMember}
+          groupId="56e7b16b-7ba3-41b7-a850-fd4d0ce8d41e"
         />
       )}
     </div>

--- a/src/components/PrayCard.jsx
+++ b/src/components/PrayCard.jsx
@@ -3,16 +3,16 @@ import { AiOutlineEdit, AiOutlineSave, AiOutlineClose } from "react-icons/ai";
 import usePrayCard from "../hooks/usePrayCard";
 
 const PrayCard = ({ isOpen, onClose, member, groupId }) => {
+  const lastestPrayCard = member.prayCards.at(-1);
   const {
     isEditing,
-    prayerDetails,
+    userInput,
     hasPrayed,
-    handleCreateClick,
     handleEditClick,
     handleSaveClick,
     handleChange,
     handlePrayClick,
-  } = usePrayCard(member.pray_summary, member.id);
+  } = usePrayCard(lastestPrayCard);
 
   if (!isOpen) return null;
 
@@ -38,17 +38,17 @@ const PrayCard = ({ isOpen, onClose, member, groupId }) => {
         <div className="flex justify-between items-center mb-4">
           {isEditing && member.isCurrentUser ? (
             <textarea
-              value={prayerDetails}
+              value={userInput}
               onChange={handleChange}
               className="w-full p-2 border rounded"
             />
           ) : (
-            <p>{prayerDetails}</p>
+            <p>{userInput}</p>
           )}
           {member.isCurrentUser &&
             (isEditing ? (
               <AiOutlineSave
-                onClick={handleSaveClick}
+                onClick={() => handleSaveClick(groupId, lastestPrayCard)}
                 className="text-blue-500 cursor-pointer ml-2"
                 size={24}
               />
@@ -65,12 +65,6 @@ const PrayCard = ({ isOpen, onClose, member, groupId }) => {
             <div className="mt-5 mb-5">
               <PrayerList />
             </div>
-            <button
-              onClick={() => handleCreateClick(groupId, "기도카드 내용")}
-              className="px-4 py-2 rounded w-full mt-4 bg-green-500 text-white"
-            >
-              기도카드 만들기
-            </button>
           </>
         )}
         <button

--- a/src/components/PrayCard.jsx
+++ b/src/components/PrayCard.jsx
@@ -61,11 +61,9 @@ const PrayCard = ({ isOpen, onClose, member, groupId }) => {
             ))}
         </div>
         {member.isCurrentUser && (
-          <>
-            <div className="mt-5 mb-5">
-              <PrayerList />
-            </div>
-          </>
+          <div className="mt-5 mb-5">
+            <PrayerList />
+          </div>
         )}
         <button
           onClick={handlePrayClick}

--- a/src/components/PrayCard.jsx
+++ b/src/components/PrayCard.jsx
@@ -2,11 +2,12 @@ import PrayerList from "./PrayerList";
 import { AiOutlineEdit, AiOutlineSave, AiOutlineClose } from "react-icons/ai";
 import usePrayCard from "../hooks/usePrayCard";
 
-const PrayCard = ({ isOpen, onClose, member }) => {
+const PrayCard = ({ isOpen, onClose, member, groupId }) => {
   const {
     isEditing,
     prayerDetails,
     hasPrayed,
+    handleCreateClick,
     handleEditClick,
     handleSaveClick,
     handleChange,
@@ -60,9 +61,17 @@ const PrayCard = ({ isOpen, onClose, member }) => {
             ))}
         </div>
         {member.isCurrentUser && (
-          <div className="mt-5 mb-5">
-            <PrayerList />
-          </div>
+          <>
+            <div className="mt-5 mb-5">
+              <PrayerList />
+            </div>
+            <button
+              onClick={() => handleCreateClick(groupId, "기도카드 내용")}
+              className="px-4 py-2 rounded w-full mt-4 bg-green-500 text-white"
+            >
+              기도카드 만들기
+            </button>
+          </>
         )}
         <button
           onClick={handlePrayClick}

--- a/src/hooks/usePrayCard.js
+++ b/src/hooks/usePrayCard.js
@@ -6,6 +6,13 @@ const usePrayCard = (initialPrayer, memberId) => {
   const [prayerDetails, setPrayerDetails] = useState(initialPrayer);
   const [hasPrayed, setHasPrayed] = useState(false);
 
+  const handleCreateClick = async (groupId, content) => {
+    await supabase.from("pray_card").insert({
+      group_id: groupId,
+      content: content,
+    });
+  };
+
   const handleEditClick = () => {
     setIsEditing(true);
   };
@@ -31,6 +38,7 @@ const usePrayCard = (initialPrayer, memberId) => {
     isEditing,
     prayerDetails,
     hasPrayed,
+    handleCreateClick,
     handleEditClick,
     handleSaveClick,
     handleChange,

--- a/src/hooks/usePrayCard.js
+++ b/src/hooks/usePrayCard.js
@@ -1,33 +1,40 @@
 import { useState } from "react";
 import { supabase } from "../supaClient";
 
-const usePrayCard = (initialPrayer, memberId) => {
+const usePrayCard = (lastestPrayCard) => {
   const [isEditing, setIsEditing] = useState(false);
-  const [prayerDetails, setPrayerDetails] = useState(initialPrayer);
+  const [userInput, setUserInput] = useState(
+    lastestPrayCard ? lastestPrayCard.content : "아직 기도제목이 없어요"
+  );
   const [hasPrayed, setHasPrayed] = useState(false);
 
-  const handleCreateClick = async (groupId, content) => {
-    await supabase.from("pray_card").insert({
-      group_id: groupId,
-      content: content,
-    });
-  };
-
   const handleEditClick = () => {
+    if (userInput === "아직 기도제목이 없어요") {
+      setUserInput("");
+    }
     setIsEditing(true);
   };
 
-  const handleSaveClick = async () => {
-    const { data } = await supabase
-      .from("member")
-      .update({ pray_summary: prayerDetails })
-      .eq("id", memberId);
-    console.log(data);
+  const handleSaveClick = async (groupId, prayCard) => {
+    if (!prayCard) {
+      await supabase.from("pray_card").insert({
+        group_id: groupId,
+        content: userInput,
+      });
+
+      setIsEditing(false);
+      return;
+    }
+    await supabase
+      .from("pray_card")
+      .update({ content: userInput })
+      .eq("id", prayCard.id);
+
     setIsEditing(false);
   };
 
   const handleChange = (e) => {
-    setPrayerDetails(e.target.value);
+    setUserInput(e.target.value);
   };
 
   const handlePrayClick = () => {
@@ -36,9 +43,8 @@ const usePrayCard = (initialPrayer, memberId) => {
 
   return {
     isEditing,
-    prayerDetails,
+    userInput,
     hasPrayed,
-    handleCreateClick,
     handleEditClick,
     handleSaveClick,
     handleChange,


### PR DESCRIPTION


![image](https://github.com/Team-Visioneer/PrayU-web/assets/82504981/63998294-4854-4c19-bf47-68a21cb1e8fb)


### 작업설명

기존에 기도제목이 member.pray_summary 에서 관리되고 있던 부분을
prayCard 가 생성되도록 변경하였습니다.
prayCard 는 자신의 최신 PrayCard 가 노출되도록 하였습니다.

### 체크리스트
- [x]  기도 카드 생성 버튼(임시)
- [x]  Member 쿼리 변경
    - [x]  맴버 불러오고 유저 아이디별 기도카드 다 불러오기
    - [x]  맴버 객체에 prayCards 로 담아서 주기
- [x]  PrayCards.jsx 에서 prayCards 보여주기
- [x]  기도카드 사용자 인풋으로 생성하기