### PR TITLE
test: api 분리 테스트

### DIFF
--- a/src/apis/group.js
+++ b/src/apis/group.js
@@ -1,26 +1,71 @@
 import { supabase } from "../supaClient";
+import { createMember } from "./member";
 
-export const fetchGroup = async (user_id) => {
-  const { data, error } = await supabase
+export async function fetchGroupsByUserId(userId) {
+  // Fetch the groups where the user is a member
+  const { data: memberData, error: memberError } = await supabase
+    .from("member")
+    .select("group_id")
+    .eq("user_id", userId)
+    .is("deleted_at", null);
+
+  if (memberError) {
+    console.error("Error fetching member data:", memberError);
+    return [];
+  }
+
+  if (memberData.length === 0) {
+    return [];
+  }
+
+  const groupIds = memberData.map((member) => member.group_id);
+
+  // Fetch group details for the group IDs
+  const { data: groupData, error: groupError } = await supabase
     .from("group")
     .select("*")
-    .eq("user_id", user_id);
+    .in("id", groupIds)
+    .is("deleted_at", null);
 
-  if (error) {
-    console.error("Error fetching group:", error);
+  if (groupError) {
+    console.error("Error fetching group data:", groupError);
+    return [];
+  }
+
+  return groupData;
+}
+
+export async function createGroup(userId, groupName, groupIntro) {
+  // 그룹 생성
+  const { data: groupData, error: groupError } = await supabase
+    .from("group")
+    .insert([
+      {
+        user_id: userId,
+        name: groupName,
+        intro: groupIntro,
+      },
+    ])
+    .select();
+
+  if (groupError) {
+    console.error("Error creating group:", groupError);
     return null;
   }
 
-  return data;
-};
+  const groupId = groupData[0].id;
 
-export const createGroup = async (group) => {
-  const { data, error } = await supabase.from("group").insert([group]);
+  // 그룹 생성자가 자동으로 그룹의 멤버가 되도록 추가
+  const memberData = createMember(userId, groupId);
 
-  if (error) {
-    console.error("Error creating group:", error);
-    return null;
-  }
+  memberData
+    .then((data) => {
+      console.log("member created", data);
+    })
+    .catch((error) => {
+      console.error("Error creating member:", error);
+    });
 
-  return data;
-};
+  console.log("group created>>", groupData[0]);
+  return groupData[0];
+}

--- a/src/apis/group.js
+++ b/src/apis/group.js
@@ -63,16 +63,13 @@ export async function createGroup(userId, groupName, groupIntro) {
 
   const groupId = groupData[0].id;
 
-  const memberData = createMember(userId, groupId);
+  const memberData = await createMember(userId, groupId);
 
   memberData
-    .then((data) => {
-      console.log("member created", data);
-    })
+    .then((data) => {})
     .catch((error) => {
       console.error("Error creating member:", error);
     });
 
-  console.log("group created>>", groupData[0]);
   return groupData[0];
 }

--- a/src/apis/group.js
+++ b/src/apis/group.js
@@ -65,11 +65,5 @@ export async function createGroup(userId, groupName, groupIntro) {
 
   const memberData = await createMember(userId, groupId);
 
-  memberData
-    .then((data) => {})
-    .catch((error) => {
-      console.error("Error creating member:", error);
-    });
-
   return groupData[0];
 }

--- a/src/apis/group.js
+++ b/src/apis/group.js
@@ -2,7 +2,6 @@ import { supabase } from "../supaClient";
 import { createMember } from "./member";
 
 export async function fetchGroupsByUserId(userId) {
-  // Fetch the groups where the user is a member
   const { data: memberData, error: memberError } = await supabase
     .from("member")
     .select("group_id")
@@ -20,7 +19,17 @@ export async function fetchGroupsByUserId(userId) {
 
   const groupIds = memberData.map((member) => member.group_id);
 
-  // Fetch group details for the group IDs
+  const groupData = await fetchGroupByGroupsId(groupIds);
+
+  if (groupData.length === 0) {
+    console.error("Error fetching group data:", groupData);
+    return [];
+  }
+
+  return groupData;
+}
+
+export async function fetchGroupByGroupsId(groupIds) {
   const { data: groupData, error: groupError } = await supabase
     .from("group")
     .select("*")
@@ -36,7 +45,6 @@ export async function fetchGroupsByUserId(userId) {
 }
 
 export async function createGroup(userId, groupName, groupIntro) {
-  // 그룹 생성
   const { data: groupData, error: groupError } = await supabase
     .from("group")
     .insert([
@@ -55,7 +63,6 @@ export async function createGroup(userId, groupName, groupIntro) {
 
   const groupId = groupData[0].id;
 
-  // 그룹 생성자가 자동으로 그룹의 멤버가 되도록 추가
   const memberData = createMember(userId, groupId);
 
   memberData

--- a/src/apis/group.js
+++ b/src/apis/group.js
@@ -1,0 +1,26 @@
+import { supabase } from "../supaClient";
+
+export const fetchGroup = async (user_id) => {
+  const { data, error } = await supabase
+    .from("group")
+    .select("*")
+    .eq("user_id", user_id);
+
+  if (error) {
+    console.error("Error fetching group:", error);
+    return null;
+  }
+
+  return data;
+};
+
+export const createGroup = async (group) => {
+  const { data, error } = await supabase.from("group").insert([group]);
+
+  if (error) {
+    console.error("Error creating group:", error);
+    return null;
+  }
+
+  return data;
+};

--- a/src/apis/member.js
+++ b/src/apis/member.js
@@ -1,1 +1,59 @@
 import { supabase } from "../supaClient";
+import { fetchProfiles } from "./profiles";
+import { fetchPrayCards } from "./pray_card";
+
+export function createMember(userId, groupId) {
+  return supabase
+    .from("member")
+    .insert([
+      {
+        user_id: userId,
+        group_id: groupId,
+      },
+    ])
+    .select();
+}
+
+export async function fetchMembers(group_id) {
+  const { data, error } = await supabase
+    .from("member")
+    .select("*")
+    .eq("group_id", group_id)
+    .is("deleted_at", null);
+
+  if (error) {
+    console.error("Error fetching members:", error);
+    return [];
+  }
+
+  return data;
+}
+
+export async function fetchMemberByGroupId(group_id, currentUserId) {
+  const members = await fetchMembers(group_id);
+  const user_ids = members.map((member) => member.user_id);
+  const profiles = await fetchProfiles(user_ids);
+  const prayCards = await fetchPrayCards(user_ids);
+  const userIdPrayCardHash = prayCards.reduce((acc, prayCard) => {
+    const userId = prayCard.user_id;
+    if (!acc[userId]) {
+      acc[userId] = [];
+    }
+    acc[userId].push(prayCard);
+    return acc;
+  }, {});
+
+  const membersWithProfiles = members.map((member) => ({
+    ...member,
+    full_name:
+      profiles.find((profile) => profile.id === member.user_id)?.full_name ||
+      "Unknown",
+    avatar_url:
+      profiles.find((profile) => profile.id === member.user_id)?.avatar_url ||
+      "",
+    isCurrentUser: member.user_id === currentUserId,
+    prayCards: userIdPrayCardHash[member.user_id] || [],
+  }));
+
+  return membersWithProfiles;
+}

--- a/src/apis/member.js
+++ b/src/apis/member.js
@@ -1,0 +1,1 @@
+import { supabase } from "../supaClient";

--- a/src/apis/member.js
+++ b/src/apis/member.js
@@ -2,8 +2,8 @@ import { supabase } from "../supaClient";
 import { fetchProfiles } from "./profiles";
 import { fetchPrayCards } from "./pray_card";
 
-export function createMember(userId, groupId) {
-  return supabase
+export async function createMember(userId, groupId) {
+  const { data, error } = await supabase
     .from("member")
     .insert([
       {
@@ -12,6 +12,13 @@ export function createMember(userId, groupId) {
       },
     ])
     .select();
+
+  if (error) {
+    console.error("Error creating member:", error);
+    return null;
+  }
+
+  return data;
 }
 
 export async function fetchMembers(group_id) {

--- a/src/apis/pray.js
+++ b/src/apis/pray.js
@@ -6,7 +6,6 @@ export async function fetchPray(prayCardId) {
     return { data: null, error: "Invalid prayCardId" };
   }
 
-  // Fetch prays for the given pray_card_id
   const { data, error } = await supabase
     .from("pray")
     .select("*")

--- a/src/apis/pray.js
+++ b/src/apis/pray.js
@@ -1,0 +1,22 @@
+import { supabase } from "../supaClient";
+
+export async function fetchPray(prayCardId) {
+  if (!prayCardId) {
+    console.error("Invalid prayCardId");
+    return { data: null, error: "Invalid prayCardId" };
+  }
+
+  // Fetch prays for the given pray_card_id
+  const { data, error } = await supabase
+    .from("pray")
+    .select("*")
+    .eq("pray_card_id", prayCardId)
+    .is("deleted_at", null);
+
+  if (error) {
+    console.error("Error fetching prays:", error.message);
+    return { data: null, error: error.message };
+  }
+
+  return { data, error: null };
+}

--- a/src/apis/pray_card.js
+++ b/src/apis/pray_card.js
@@ -1,1 +1,17 @@
 import { supabase } from "../supaClient";
+
+export async function fetchPrayCards(user_ids) {
+  const { data, error } = await supabase
+    .from("pray_card")
+    .select("*")
+    .in("user_id", user_ids)
+    .is("deleted_at", null)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    console.error("Error fetching pray cards:", error);
+    return [];
+  }
+
+  return data;
+}

--- a/src/apis/pray_card.js
+++ b/src/apis/pray_card.js
@@ -1,0 +1,1 @@
+import { supabase } from "../supaClient";

--- a/src/apis/profiles.js
+++ b/src/apis/profiles.js
@@ -1,0 +1,14 @@
+import { supabase } from "../supaClient";
+export async function fetchProfiles(user_ids) {
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("id, full_name, avatar_url")
+    .in("id", user_ids);
+
+  if (error) {
+    console.error("Error fetching profiles:", error);
+    return [];
+  }
+
+  return data;
+}

--- a/src/hooks/useMember.js
+++ b/src/hooks/useMember.js
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { supabase } from "../supaClient";
 import { useNavigate } from "react-router-dom";
-import { fetchGroup } from "../apis/group";
 import { fetchMemberByGroupId } from "../apis/member";
 
 const useMember = (groupId) => {

--- a/src/hooks/useMember.js
+++ b/src/hooks/useMember.js
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { supabase } from "../supaClient";
 import { useNavigate } from "react-router-dom";
+import { fetchGroup } from "../apis/group";
 
 const useMember = (groupId) => {
   const [members, setMembers] = useState([]);
@@ -84,6 +85,11 @@ const useMember = (groupId) => {
       acc[userId].push(prayCard);
       return acc;
     }, {});
+
+    //test place
+    const result = await fetchGroup("60540ce8-e483-4a1b-872b-06c95a47cc2e");
+    console.log("result>>", result);
+    //test place
 
     const membersWithProfiles = members.map((member) => ({
       ...member,

--- a/src/hooks/useMember.js
+++ b/src/hooks/useMember.js
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { supabase } from "../supaClient";
 import { useNavigate } from "react-router-dom";
 import { fetchGroup } from "../apis/group";
+import { fetchMemberByGroupId } from "../apis/member";
 
 const useMember = (groupId) => {
   const [members, setMembers] = useState([]);
@@ -18,7 +19,8 @@ const useMember = (groupId) => {
     } = await supabase.auth.getSession();
     setSession(session);
     if (session) {
-      await fetchMemberByGroupId(groupId, session.user.id);
+      const data = await fetchMemberByGroupId(groupId, session.user.id);
+      setMembers(data);
     }
     setLoading(false);
   }, [groupId]);
@@ -26,85 +28,6 @@ const useMember = (groupId) => {
   useEffect(() => {
     fetchSession();
   }, [fetchSession]);
-
-  async function fetchMembers(group_id) {
-    const { data, error } = await supabase
-      .from("member")
-      .select("*")
-      .eq("group_id", group_id)
-      .is("deleted_at", null);
-
-    if (error) {
-      console.error("Error fetching members:", error);
-      return [];
-    }
-
-    return data;
-  }
-
-  async function fetchPrayCards(user_ids) {
-    const { data, error } = await supabase
-      .from("pray_card")
-      .select("*")
-      .in("user_id", user_ids)
-      .is("deleted_at", null)
-      .order("created_at", { ascending: false });
-
-    if (error) {
-      console.error("Error fetching pray cards:", error);
-      return [];
-    }
-
-    return data;
-  }
-
-  async function fetchProfiles(user_ids) {
-    const { data, error } = await supabase
-      .from("profiles")
-      .select("id, full_name, avatar_url")
-      .in("id", user_ids);
-
-    if (error) {
-      console.error("Error fetching profiles:", error);
-      return [];
-    }
-
-    return data;
-  }
-
-  async function fetchMemberByGroupId(group_id, currentUserId) {
-    const members = await fetchMembers(group_id);
-    const user_ids = members.map((member) => member.user_id);
-    const profiles = await fetchProfiles(user_ids);
-    const prayCards = await fetchPrayCards(user_ids);
-    const userIdPrayCardHash = prayCards.reduce((acc, prayCard) => {
-      const userId = prayCard.user_id;
-      if (!acc[userId]) {
-        acc[userId] = [];
-      }
-      acc[userId].push(prayCard);
-      return acc;
-    }, {});
-
-    //test place
-    const result = await fetchGroup("60540ce8-e483-4a1b-872b-06c95a47cc2e");
-    console.log("result>>", result);
-    //test place
-
-    const membersWithProfiles = members.map((member) => ({
-      ...member,
-      full_name:
-        profiles.find((profile) => profile.id === member.user_id)?.full_name ||
-        "Unknown",
-      avatar_url:
-        profiles.find((profile) => profile.id === member.user_id)?.avatar_url ||
-        "",
-      isCurrentUser: member.user_id === currentUserId,
-      prayCards: userIdPrayCardHash[member.user_id] || [],
-    }));
-
-    setMembers(membersWithProfiles);
-  }
 
   const openModal = (member) => {
     setSelectedMember(member);


### PR DESCRIPTION
api 콜 함수들을 관리하는 폴더를 만들고 각 함수들을 구현했습니다. 이후 이전에 쓰인 함수들을 새로 정리한 함수로 대체했습니다.

src/apis/  폴더 내에 각 테이블 별로 함수 정리된 파일들을 정의했습니다.

만든 함수들은 다음과 같습니다.


- group
    - **fetchGroupByUserId**. :  내 그룹목록들 조회
        - (현재 유저의 Profiles id) ⇒ {유저가 속한 group row 전체들 반환)
        
    - **createGroup** : 새 그룹 생성
        - (유저아이디, 그룹이름, 소개글) ⇒  {그룹을 만들고 이 그룹장도 멤버이므로 멤버도 새로 생성. 반환값은 생성된 그룹 row}

- member
    - **fetchMemberByGroupId** : 그룹에 속한 나를 포함한 멤버들 조회
        - (그룹 아이디, 현재 유저 아이디) ⇒ {그룹의 각 멤버데이터와 프로필데이터를 결합해서 반환}
    
    - **createMember** : 그룹에 새 맴버 추가
        - (유저아이디, 그룹아이디) ⇒ {생성된 멤버 데이터 row}
        - 새로 초대하는 유저. 즉 서비스 아직 안한 사람에 대해서 별도 함수 내 분기처리는 추후에
        - pray_summary도 나중에

- pray
    - **fetchPray** : 내게 해준 기도들 조회 (일단은 전부 조회하겠음.api콜하는부분에서 일주일 필터링하는걸로?)
        - (프레이시트 id를 인자로) ⇒ {기도시트에 연결된 모든pray row들 반환}
    
    - createPray : 그룹에 속한 멤버의 기도카드에 기도 생성
        - 명준이 형이 동시에 만들고 있어서 나중에 그걸 옮기자.

- pray_card
    - **fetchPrayCards** : 그룹에 속한 멤버(나 포함)의 기도카드 조회
        - (유저아이디)⇒ {유저가 생성한 기도카드들의 row 반환}
    
    - createPrayCardByGroupId : 특정 그룹 내의 내 기도카드 생성
        - 명준이 형이 동시에 만들고 있어서 나중에 그걸 옮기자.

- profiles
    - **fetchProfiles** : 인자로 전달받은 user 들의 프로필 조회.