### PR TITLE
refactor: useAuth 생성

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,8 @@ import Main from "./components/Main";
 import NotFound from "./components/NotFound";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "./components/AuthProvider";
+import LoginPage from "./pages/LoginPage";
+import PrivateRoute from "./components/PrivateRoute";
 
 const App = () => {
   return (
@@ -14,9 +16,16 @@ const App = () => {
           <AuthProvider>
             <Routes>
               <Route path="/" element={<Main />}></Route>
-              <Route path="/login/" element={<Login />}></Route>
+              <Route path="/login/" element={<LoginPage />}></Route>
               <Route path="/login/:paramsGroupId" element={<Login />}></Route>
-              <Route path="/group/:groupId" element={<Group />}></Route>
+              <Route
+                path="/group/:groupId"
+                element={
+                  <PrivateRoute>
+                    <Group />
+                  </PrivateRoute>
+                }
+              ></Route>
               <Route path="/group/" element={<Group />}></Route>
               <Route path="/group-create" element={<CreateGroup />}></Route>
               <Route path="*" element={<NotFound />}></Route>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,21 +4,24 @@ import Login from "./components/Login";
 import Main from "./components/Main";
 import NotFound from "./components/NotFound";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { AuthProvider } from "./components/AuthProvider";
 
 const App = () => {
   return (
     <div className="App h-screen">
       <div className="mx-auto max-w-[600px] ">
         <BrowserRouter>
-          <Routes>
-            <Route path="/" element={<Main />}></Route>
-            <Route path="/login/" element={<Login />}></Route>
-            <Route path="/login/:paramsGroupId" element={<Login />}></Route>
-            <Route path="/group/:groupId" element={<Group />}></Route>
-            <Route path="/group/" element={<Group />}></Route>
-            <Route path="/group-create" element={<CreateGroup />}></Route>
-            <Route path="*" element={<NotFound />}></Route>
-          </Routes>
+          <AuthProvider>
+            <Routes>
+              <Route path="/" element={<Main />}></Route>
+              <Route path="/login/" element={<Login />}></Route>
+              <Route path="/login/:paramsGroupId" element={<Login />}></Route>
+              <Route path="/group/:groupId" element={<Group />}></Route>
+              <Route path="/group/" element={<Group />}></Route>
+              <Route path="/group-create" element={<CreateGroup />}></Route>
+              <Route path="*" element={<NotFound />}></Route>
+            </Routes>
+          </AuthProvider>
         </BrowserRouter>
       </div>
     </div>

--- a/src/components/AuthProvider.jsx
+++ b/src/components/AuthProvider.jsx
@@ -1,0 +1,43 @@
+// src/components/AuthProvider.jsx
+import { createContext, useState, useEffect } from "react";
+import { supabase } from "../supaClient";
+
+const AuthContext = createContext();
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const checkUser = async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      setUser(session?.user || null);
+      setLoading(false);
+    };
+
+    checkUser();
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user || null);
+    });
+
+    return () => subscription.unsubscribe();
+  }, []);
+
+  const signOut = async () => {
+    await supabase.auth.signOut();
+    setUser(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, loading, signOut }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export { AuthContext };

--- a/src/components/Group.jsx
+++ b/src/components/Group.jsx
@@ -4,8 +4,12 @@ import useMember from "../hooks/useMember";
 import { useParams } from "react-router-dom";
 import useGroup from "../hooks/useGroup";
 import { ClipLoader } from "react-spinners";
+import useAuth from "../hooks/useAuth";
 
 const Group = () => {
+  const { user } = useAuth();
+  console.log(user);
+
   const { groupId } = useParams();
   const { groupName } = useGroup(groupId);
   const {

--- a/src/components/Group.jsx
+++ b/src/components/Group.jsx
@@ -8,7 +8,6 @@ import useAuth from "../hooks/useAuth";
 
 const Group = () => {
   const { user } = useAuth();
-  console.log(user);
 
   const { groupId } = useParams();
   const { groupName } = useGroup(groupId);

--- a/src/components/PrivateRout.jsx
+++ b/src/components/PrivateRout.jsx
@@ -1,0 +1,23 @@
+import { Navigate } from "react-router-dom";
+import useAuth from "../hooks/useAuth";
+import ClipLoader from "react-spinners/ClipLoader";
+
+const PrivateRoute = ({ children }) => {
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center h-screen">
+        <ClipLoader size={50} color={"#123abc"} loading={true} />
+      </div>
+    );
+  }
+
+  if (!user) {
+    return <Navigate to="/login" />; // 로그인되지 않은 경우 리다이렉트
+  }
+
+  return children; // 로그인된 경우 자식 컴포넌트 렌더링
+};
+
+export default PrivateRoute;

--- a/src/components/PrivateRoute.jsx
+++ b/src/components/PrivateRoute.jsx
@@ -1,9 +1,10 @@
-import { Navigate } from "react-router-dom";
+import { Navigate, useLocation } from "react-router-dom";
 import useAuth from "../hooks/useAuth";
 import ClipLoader from "react-spinners/ClipLoader";
 
 const PrivateRoute = ({ children }) => {
   const { user, loading } = useAuth();
+  const location = useLocation();
 
   if (loading) {
     return (
@@ -14,7 +15,7 @@ const PrivateRoute = ({ children }) => {
   }
 
   if (!user) {
-    return <Navigate to="/login" />; // 로그인되지 않은 경우 리다이렉트
+    return <Navigate to="/login" state={{ from: location }} />; // 로그인되지 않은 경우 리다이렉트
   }
 
   return children; // 로그인된 경우 자식 컴포넌트 렌더링

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,0 +1,8 @@
+import { useContext } from "react";
+import { AuthContext } from "../components/AuthProvider";
+
+const useAuth = () => {
+  return useContext(AuthContext);
+};
+
+export default useAuth;

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,12 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+
+const container = document.getElementById("root");
+const root = createRoot(container);
+
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,0 +1,32 @@
+import { useLocation, useNavigate } from "react-router-dom";
+import { Auth } from "@supabase/auth-ui-react";
+import { supabase } from "../supaClient";
+import { ThemeSupa } from "@supabase/auth-ui-shared";
+import useAuth from "../hooks/useAuth";
+
+const LoginPage = () => {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  if (user) {
+    navigate("/group", { replace: true });
+  }
+
+  const location = useLocation();
+  const from = location.state?.from?.pathname || "/group";
+
+  const redirectUrl = `${import.meta.env.VITE_BASE_URL}${from}`;
+  return (
+    <div>
+      <h3 className="text-center text-5xl mt-10">안녕하세요, PrayU입니다.</h3>
+      <Auth
+        redirectTo={redirectUrl}
+        supabaseClient={supabase}
+        appearance={{ theme: ThemeSupa }}
+        onlyThirdPartyProviders
+        providers={["kakao"]}
+      />
+    </div>
+  );
+};
+
+export default LoginPage;


### PR DESCRIPTION
로그인쪽은 중요한 부분인 것 같아 더이상 이슈가 나지 않도록 처리하는게 좋을 것 같다고 생각했습니다.

로그인이 필요한 페이지에서 전역적으로 사용할 수 있도록 AuthProvider.jsx 와 useAuth 를 만들었습니다.

실제로 유저 정보가 필요한 page 에서
 const { user } = useAuth();   를 통해 user 정보에 바로 접근 가능합니다.
로그인이 되어있지 않은 경우 로그인 페이지로 리다이렉트 됩니다.

이후 group 페이지에서도 fetchSession 대신   const { user } = useAuth();  를 통해서 유저 정보를 확인하면 좋을 것 같습니다.