### PR TITLE
fix: PrayCard 관련 수정

### DIFF
--- a/src/apis/member.js
+++ b/src/apis/member.js
@@ -1,6 +1,6 @@
 import { supabase } from "../supaClient";
 import { fetchProfiles } from "./profiles";
-import { fetchPrayCards } from "./pray_card";
+import { fetchGroupPrayCards } from "./pray_card";
 
 export async function createMember(userId, groupId) {
   const { data, error } = await supabase
@@ -36,14 +36,14 @@ export async function fetchMembers(group_id) {
 }
 
 export async function fetchMemberByGroupId(
-  group_id,
+  groupId,
   currentUserId,
   lastInsertTimeRef
 ) {
-  let members = await fetchMembers(group_id);
-  const user_ids = members.map((member) => member.user_id);
-  const profiles = await fetchProfiles(user_ids);
-  const prayCards = await fetchPrayCards(user_ids);
+  let members = await fetchMembers(groupId);
+  const userIds = members.map((member) => member.user_id);
+  const profiles = await fetchProfiles(userIds);
+  const prayCards = await fetchGroupPrayCards(groupId, userIds);
   const userIdPrayCardHash = prayCards.reduce((acc, prayCard) => {
     const userId = prayCard.user_id;
     if (!acc[userId]) {
@@ -66,7 +66,7 @@ export async function fetchMemberByGroupId(
 
     const { data, error } = await supabase
       .from("member")
-      .insert([{ user_id: currentUserId, group_id }])
+      .insert([{ user_id: currentUserId, groupId }])
       .select();
 
     if (error) {

--- a/src/apis/pray.js
+++ b/src/apis/pray.js
@@ -1,10 +1,13 @@
 import { supabase } from "../supaClient";
 
-export const fetchPrayData = async (prayCardId) => {
+export const fetchPrayData = async (prayCard) => {
+  if (!prayCard) {
+    return [];
+  }
   const { data, error } = await supabase
     .from("pray")
     .select("*")
-    .eq("pray_card_id", prayCardId)
+    .eq("pray_card_id", prayCard.id)
     .is("deleted_at", null);
 
   if (error) {

--- a/src/apis/pray_card.js
+++ b/src/apis/pray_card.js
@@ -1,10 +1,11 @@
 import { supabase } from "../supaClient";
 
-export async function fetchPrayCards(user_ids) {
+export async function fetchGroupPrayCards(groupId, userIds) {
   const { data, error } = await supabase
     .from("pray_card")
     .select("*")
-    .in("user_id", user_ids)
+    .in("user_id", userIds)
+    .eq("group_id", groupId)
     .is("deleted_at", null)
     .order("created_at", { ascending: false });
 

--- a/src/components/Group.jsx
+++ b/src/components/Group.jsx
@@ -41,9 +41,8 @@ const Group = () => {
         <h1 className="">My</h1>
         {currentMember ? (
           <Profile
+            member={currentMember}
             onClick={() => openModal(currentMember, currentMember.prayCards[0])}
-            name={currentMember.full_name}
-            avatar_url={currentMember.avatar_url}
           />
         ) : (
           <div className="text-red-500">No current user found</div>
@@ -55,9 +54,8 @@ const Group = () => {
           {otherMembers.map((member) => (
             <Profile
               key={member.id}
-              name={member.full_name}
+              member={member}
               onClick={() => openModal(member, member.prayCards[0])}
-              avatar_url={member.avatar_url}
             />
           ))}
         </ul>

--- a/src/components/PrayCard.jsx
+++ b/src/components/PrayCard.jsx
@@ -79,7 +79,7 @@ const PrayCard = ({
           />
         </div>
         <button
-          onClick={() => handlePrayClick(prayCard.id)}
+          onClick={() => handlePrayClick(prayCard)}
           className={`px-4 py-2 rounded w-full mt-4 ${
             hasPrayed ? "bg-gray-500 text-white" : "bg-green-500 text-white"
           }`}

--- a/src/components/Profile.jsx
+++ b/src/components/Profile.jsx
@@ -19,7 +19,7 @@ const Profile = ({ member, onClick }) => {
         {member.prayCards[0]?.content || "아직 기도제목이 없어요"}
       </div>
       <div className="text-gray-500">
-        {formatDateString(member.prayCards[0]?.created_at) || "-"}
+        {formatDateString(member.prayCards[0]?.updated_at) || "-"}
       </div>
     </div>
   );

--- a/src/components/Profile.jsx
+++ b/src/components/Profile.jsx
@@ -1,17 +1,26 @@
-const Profile = ({ onClick, name, avatar_url }) => {
+import { formatDateString } from "../utils";
+
+const Profile = ({ member, onClick }) => {
   return (
     <div
       onClick={onClick}
-      className="cursor-pointer bg-gray-800 p-4 rounded mb-2 flex items-center"
+      className="flex flex-col gap-2 cursor-pointer bg-gray-800 p-4 rounded mb-2"
     >
-      {avatar_url && (
+      <div className="flex items-center">
         <img
-          src={avatar_url}
-          alt={`${name}'s avatar`}
+          src={member.avatar_url}
+          alt={`${member.name}'s avatar`}
           className="w-5 h-5 rounded-full mr-4"
         />
-      )}
-      <h2 className="text-white">{name}</h2>
+        <h3 className="text-white">{member.name}</h3>
+      </div>
+
+      <div className="text-white">
+        {member.prayCards[0]?.content || "아직 기도제목이 없어요"}
+      </div>
+      <div className="text-gray-500">
+        {formatDateString(member.prayCards[0]?.created_at) || "-"}
+      </div>
     </div>
   );
 };

--- a/src/hooks/useMember.js
+++ b/src/hooks/useMember.js
@@ -66,7 +66,7 @@ const useMember = (groupId) => {
   }, [groupId]);
 
   const openModal = async (member, prayCard) => {
-    const prayData = await fetchPrayData(prayCard.id);
+    const prayData = await fetchPrayData(prayCard);
     setPrayCard(prayCard);
     setPrayData(prayData);
     setSelectedMember(member);

--- a/src/hooks/usePrayCard.js
+++ b/src/hooks/usePrayCard.js
@@ -36,9 +36,13 @@ const usePrayCard = (lastestPrayCard) => {
     setUserInput(e.target.value);
   };
 
-  const handlePrayClick = async (prayCardId) => {
+  const handlePrayClick = async (prayCard) => {
+    if (!prayCard) {
+      console.error("prayCard is not defined");
+      return null;
+    }
     await supabase.from("pray").insert({
-      pray_card_id: prayCardId,
+      pray_card_id: prayCard.id,
     });
     setHasPrayed(true);
   };

--- a/src/hooks/usePrayCard.js
+++ b/src/hooks/usePrayCard.js
@@ -26,7 +26,7 @@ const usePrayCard = (lastestPrayCard) => {
     }
     await supabase
       .from("pray_card")
-      .update({ content: userInput })
+      .update({ content: userInput, updated_at: new Date() })
       .eq("id", prayCard.id);
 
     setIsEditing(false);

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,3 +2,12 @@ export const getDayOfWeek = (dateString) => {
   const date = new Date(dateString);
   return date.toLocaleDateString("en-US", { weekday: "long" });
 };
+
+export const formatDateString = (dateString) => {
+  if (!dateString) return null;
+  const date = new Date(dateString);
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  return `${year}.${month}.${day}`;
+};


### PR DESCRIPTION
![image](https://github.com/Team-Visioneer/PrayU-web/assets/82504981/7aea618c-649f-410e-b0a4-53a793ed1cc8)


### 작업내용

카드에 최근 기도제목 노출과 생성날짜를 추가합니다.
카드를 불러올때 기도데이터 때문에 발생했던 에러를 수정합니다.




## 에러 사항 수정
1. 기도카드가 없을 때 PrayData 를 불러오고 있는 부분에서 에러가 있어 예외처리
2. 기도카드가 없을 때 기도버튼을 누르면 console.error 발생하도록 수정
3. 그룹 내에서 생성된 기도카드만 불러오도록 수정

https://www.notion.so/mmyeong/fix-PrayCard-c7b31c31d61344b9a2332fedb29d1683?pvs=4