### PR TITLE
feature: rls 대체 함수 추가 & 당일 중복 기도 제한

### DIFF
--- a/src/apis/member.js
+++ b/src/apis/member.js
@@ -66,7 +66,7 @@ export async function fetchMemberByGroupId(
 
     const { data, error } = await supabase
       .from("member")
-      .insert([{ user_id: currentUserId, groupId }])
+      .insert([{ user_id: currentUserId, group_id: groupId }])
       .select();
 
     if (error) {

--- a/src/components/PrayCard.jsx
+++ b/src/components/PrayCard.jsx
@@ -23,7 +23,7 @@ const PrayCard = ({
     handleChange,
     handlePrayClick,
     checkPrayDataForToday,
-  } = usePrayCard(currentMember, prayCard);
+  } = usePrayCard(prayCard);
 
   useEffect(() => {
     setHasPrayed(checkPrayDataForToday(prayData, currentMember.user_id));

--- a/src/components/PrayCard.jsx
+++ b/src/components/PrayCard.jsx
@@ -16,11 +16,41 @@ const PrayCard = ({
     isEditing,
     userInput,
     hasPrayed,
+    setHasPrayed,
     handleEditClick,
     handleSaveClick,
     handleChange,
     handlePrayClick,
-  } = usePrayCard(prayCard);
+  } = usePrayCard(prayCard /*groupId, currentMember*/);
+  console.log(">>prayCard", prayCard);
+  console.log(">>prayData", prayData);
+
+  //PrayData에 현재 유저가 오늘 이미 기도했는지 확인
+  function checkPrayDataForToday(prayData, userId) {
+    const today = new Date();
+    const startOfDay = new Date(today.setHours(0, 0, 0, 0));
+    const endOfDay = new Date(today.setHours(23, 59, 59, 999));
+
+    return prayData.some((pray) => {
+      const prayDate = new Date(pray.created_at);
+      return (
+        pray.user_id === userId &&
+        prayDate >= startOfDay &&
+        prayDate <= endOfDay
+      );
+    });
+  }
+  // const hasPrayedToday = checkPrayDataForToday(prayData, currentMember.user_id);
+  setHasPrayed(checkPrayDataForToday(prayData, currentMember.user_id));
+
+  //   if (hasPrayedToday) {
+
+  // setHasPrayed(true)
+  //     console.log(" 이미 기도했다");
+  //   } else {
+
+  //     console.log("아직 안했다");
+  //   }
 
   if (!isOpen) return null;
 
@@ -79,7 +109,13 @@ const PrayCard = ({
           />
         </div>
         <button
-          onClick={() => handlePrayClick(prayCard)}
+          onClick={() =>
+            handlePrayClick(
+              currentMember,
+              prayCard,
+              hasPrayed /* hasPrayedToday*/
+            )
+          }
           className={`px-4 py-2 rounded w-full mt-4 ${
             hasPrayed ? "bg-gray-500 text-white" : "bg-green-500 text-white"
           }`}

--- a/src/components/PrayCard.jsx
+++ b/src/components/PrayCard.jsx
@@ -1,7 +1,6 @@
 import PrayerList from "./PrayerList";
 import { AiOutlineEdit, AiOutlineSave, AiOutlineClose } from "react-icons/ai";
 import usePrayCard from "../hooks/usePrayCard";
-import { useEffect } from "react";
 
 const PrayCard = ({
   isOpen,
@@ -17,17 +16,13 @@ const PrayCard = ({
     isEditing,
     userInput,
     hasPrayed,
-    setHasPrayed,
+
     handleEditClick,
     handleSaveClick,
     handleChange,
     handlePrayClick,
-    checkPrayDataForToday,
-  } = usePrayCard(prayCard);
+  } = usePrayCard(currentMember, prayCard, prayData);
 
-  useEffect(() => {
-    setHasPrayed(checkPrayDataForToday(prayData, currentMember.user_id));
-  }, []);
   if (!isOpen) return null;
 
   return (

--- a/src/components/PrayCard.jsx
+++ b/src/components/PrayCard.jsx
@@ -1,6 +1,7 @@
 import PrayerList from "./PrayerList";
 import { AiOutlineEdit, AiOutlineSave, AiOutlineClose } from "react-icons/ai";
 import usePrayCard from "../hooks/usePrayCard";
+import { useEffect } from "react";
 
 const PrayCard = ({
   isOpen,
@@ -21,37 +22,12 @@ const PrayCard = ({
     handleSaveClick,
     handleChange,
     handlePrayClick,
-  } = usePrayCard(prayCard /*groupId, currentMember*/);
-  console.log(">>prayCard", prayCard);
-  console.log(">>prayData", prayData);
+    checkPrayDataForToday,
+  } = usePrayCard(currentMember, prayCard);
 
-  //PrayData에 현재 유저가 오늘 이미 기도했는지 확인
-  function checkPrayDataForToday(prayData, userId) {
-    const today = new Date();
-    const startOfDay = new Date(today.setHours(0, 0, 0, 0));
-    const endOfDay = new Date(today.setHours(23, 59, 59, 999));
-
-    return prayData.some((pray) => {
-      const prayDate = new Date(pray.created_at);
-      return (
-        pray.user_id === userId &&
-        prayDate >= startOfDay &&
-        prayDate <= endOfDay
-      );
-    });
-  }
-  // const hasPrayedToday = checkPrayDataForToday(prayData, currentMember.user_id);
-  setHasPrayed(checkPrayDataForToday(prayData, currentMember.user_id));
-
-  //   if (hasPrayedToday) {
-
-  // setHasPrayed(true)
-  //     console.log(" 이미 기도했다");
-  //   } else {
-
-  //     console.log("아직 안했다");
-  //   }
-
+  useEffect(() => {
+    setHasPrayed(checkPrayDataForToday(prayData, currentMember.user_id));
+  }, []);
   if (!isOpen) return null;
 
   return (
@@ -109,13 +85,7 @@ const PrayCard = ({
           />
         </div>
         <button
-          onClick={() =>
-            handlePrayClick(
-              currentMember,
-              prayCard,
-              hasPrayed /* hasPrayedToday*/
-            )
-          }
+          onClick={() => handlePrayClick(prayCard, hasPrayed)}
           className={`px-4 py-2 rounded w-full mt-4 ${
             hasPrayed ? "bg-gray-500 text-white" : "bg-green-500 text-white"
           }`}

--- a/src/components/PrayCard.jsx
+++ b/src/components/PrayCard.jsx
@@ -80,7 +80,7 @@ const PrayCard = ({
           />
         </div>
         <button
-          onClick={() => handlePrayClick(prayCard, hasPrayed)}
+          onClick={() => handlePrayClick(prayCard)}
           className={`px-4 py-2 rounded w-full mt-4 ${
             hasPrayed ? "bg-gray-500 text-white" : "bg-green-500 text-white"
           }`}

--- a/src/hooks/usePrayCard.js
+++ b/src/hooks/usePrayCard.js
@@ -1,19 +1,30 @@
 import { useState } from "react";
 import { supabase } from "../supaClient";
 
-<<<<<<< HEAD
 const usePrayCard = (member, lastestPrayCard) => {
   const [prayerText, setPrayerText] = useState(
     lastestPrayCard ? lastestPrayCard.content : ""
   );
-=======
-const usePrayCard = (lastestPrayCard /*groupId, currentMember*/) => {
->>>>>>> bd86c67 (feat: restraint function)
   const [isEditing, setIsEditing] = useState(false);
   const [userInput, setUserInput] = useState(
     lastestPrayCard ? lastestPrayCard.content : "아직 기도제목이 없어요"
   );
   const [hasPrayed, setHasPrayed] = useState(false);
+
+  const checkPrayDataForToday = (prayData, userId) => {
+    const today = new Date();
+    const startOfDay = new Date(today.setHours(0, 0, 0, 0));
+    const endOfDay = new Date(today.setHours(23, 59, 59, 999));
+
+    return prayData.some((pray) => {
+      const prayDate = new Date(pray.created_at);
+      return (
+        pray.user_id === userId &&
+        prayDate >= startOfDay &&
+        prayDate <= endOfDay
+      );
+    });
+  };
 
   const handleCreatePrayCard = async () => {
     if (prayerText.trim() === "") {
@@ -55,14 +66,9 @@ const usePrayCard = (lastestPrayCard /*groupId, currentMember*/) => {
     setUserInput(e.target.value);
   };
 
-  const handlePrayClick = async (
-    currentMember,
-    prayCard,
-    hasPrayed
-    // hasPrayedToday
-  ) => {
+  const handlePrayClick = async (prayCard, hasPrayed) => {
     if (!prayCard) {
-      console.error("prayCard is not defined");
+      console.error("기도카드가 없습니다.");
       return null;
     }
     if (hasPrayed) {
@@ -87,6 +93,7 @@ const usePrayCard = (lastestPrayCard /*groupId, currentMember*/) => {
     handleSaveClick,
     handleChange,
     handlePrayClick,
+    checkPrayDataForToday,
   };
 };
 

--- a/src/hooks/usePrayCard.js
+++ b/src/hooks/usePrayCard.js
@@ -1,16 +1,7 @@
 import { useState } from "react";
 import { supabase } from "../supaClient";
 
-const usePrayCard = (lastestPrayCard) => {
-  const [prayerText, setPrayerText] = useState(
-    lastestPrayCard ? lastestPrayCard.content : ""
-  );
-  const [isEditing, setIsEditing] = useState(false);
-  const [userInput, setUserInput] = useState(
-    lastestPrayCard ? lastestPrayCard.content : "아직 기도제목이 없어요"
-  );
-  const [hasPrayed, setHasPrayed] = useState(false);
-
+const usePrayCard = (currentMember, lastestPrayCard, prayData) => {
   const checkPrayDataForToday = (prayData, userId) => {
     const today = new Date();
     const startOfDay = new Date(today.setHours(0, 0, 0, 0));
@@ -25,6 +16,16 @@ const usePrayCard = (lastestPrayCard) => {
       );
     });
   };
+  const [prayerText, setPrayerText] = useState(
+    lastestPrayCard ? lastestPrayCard.content : ""
+  );
+  const [isEditing, setIsEditing] = useState(false);
+  const [userInput, setUserInput] = useState(
+    lastestPrayCard ? lastestPrayCard.content : "아직 기도제목이 없어요"
+  );
+  const [hasPrayed, setHasPrayed] = useState(
+    checkPrayDataForToday(prayData, currentMember.user_id)
+  );
 
   const handleCreatePrayCard = async () => {
     if (prayerText.trim() === "") {
@@ -88,12 +89,11 @@ const usePrayCard = (lastestPrayCard) => {
     isEditing,
     userInput,
     hasPrayed,
-    setHasPrayed,
+
     handleEditClick,
     handleSaveClick,
     handleChange,
     handlePrayClick,
-    checkPrayDataForToday,
   };
 };
 

--- a/src/hooks/usePrayCard.js
+++ b/src/hooks/usePrayCard.js
@@ -67,7 +67,7 @@ const usePrayCard = (currentMember, lastestPrayCard, prayData) => {
     setUserInput(e.target.value);
   };
 
-  const handlePrayClick = async (prayCard, hasPrayed) => {
+  const handlePrayClick = async (prayCard) => {
     if (!prayCard) {
       console.error("기도카드가 없습니다.");
       return null;

--- a/src/hooks/usePrayCard.js
+++ b/src/hooks/usePrayCard.js
@@ -1,10 +1,14 @@
 import { useState } from "react";
 import { supabase } from "../supaClient";
 
+<<<<<<< HEAD
 const usePrayCard = (member, lastestPrayCard) => {
   const [prayerText, setPrayerText] = useState(
     lastestPrayCard ? lastestPrayCard.content : ""
   );
+=======
+const usePrayCard = (lastestPrayCard /*groupId, currentMember*/) => {
+>>>>>>> bd86c67 (feat: restraint function)
   const [isEditing, setIsEditing] = useState(false);
   const [userInput, setUserInput] = useState(
     lastestPrayCard ? lastestPrayCard.content : "아직 기도제목이 없어요"
@@ -51,15 +55,24 @@ const usePrayCard = (member, lastestPrayCard) => {
     setUserInput(e.target.value);
   };
 
-  const handlePrayClick = async (prayCard) => {
+  const handlePrayClick = async (
+    currentMember,
+    prayCard,
+    hasPrayed
+    // hasPrayedToday
+  ) => {
     if (!prayCard) {
       console.error("prayCard is not defined");
       return null;
     }
-    await supabase.from("pray").insert({
-      pray_card_id: prayCard.id,
-    });
-    setHasPrayed(true);
+    if (hasPrayed) {
+      console.log("이미 기도했습니다");
+    } else {
+      await supabase.from("pray").insert({
+        pray_card_id: prayCard.id,
+      });
+      setHasPrayed(true);
+    }
   };
 
   return {
@@ -69,6 +82,7 @@ const usePrayCard = (member, lastestPrayCard) => {
     isEditing,
     userInput,
     hasPrayed,
+    setHasPrayed,
     handleEditClick,
     handleSaveClick,
     handleChange,

--- a/src/hooks/usePrayCard.js
+++ b/src/hooks/usePrayCard.js
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { supabase } from "../supaClient";
 
-const usePrayCard = (member, lastestPrayCard) => {
+const usePrayCard = (lastestPrayCard) => {
   const [prayerText, setPrayerText] = useState(
     lastestPrayCard ? lastestPrayCard.content : ""
   );
@@ -31,7 +31,7 @@ const usePrayCard = (member, lastestPrayCard) => {
       alert("기도제목을 작성해주셔야 그룹원들을 위해 기도할 수 있어요");
     } else {
       await supabase.from("pray_card").insert({
-        group_id: member.group_id,
+        group_id: lastestPrayCard.group_id,
         content: prayerText,
       });
       window.location.reload();
@@ -72,13 +72,13 @@ const usePrayCard = (member, lastestPrayCard) => {
       return null;
     }
     if (hasPrayed) {
-      console.log("이미 기도했습니다");
-    } else {
-      await supabase.from("pray").insert({
-        pray_card_id: prayCard.id,
-      });
-      setHasPrayed(true);
+      console.log("당일 기도 진행완료.");
+      return null;
     }
+    await supabase.from("pray").insert({
+      pray_card_id: prayCard.id,
+    });
+    setHasPrayed(true);
   };
 
   return {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,7 +4,7 @@ import App from "./App.jsx";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
+  //<React.StrictMode>
+  <App />
+  //</React.StrictMode>
 );

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,7 +4,7 @@ import App from "./App.jsx";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
-  //<React.StrictMode>
-  <App />
-  //</React.StrictMode>
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
 );


### PR DESCRIPTION
fix: member create function with no arg

feat: restraint function

feat: pray create constraint, do not show same day pray


<img width="829" alt="스크린샷 2024-07-13 오전 3 05 51" src="https://github.com/user-attachments/assets/217b613f-94c1-419b-b108-a9b3f06b449f">

<img width="872" alt="스크린샷 2024-07-13 오전 3 11 59" src="https://github.com/user-attachments/assets/eadb7f80-6fca-42f4-ac39-eadccb1eff13">



어떤 기도 카드를 대상으로 유저가 하루에 이미 기도를 한 번 했으면 더 이상 기도가 새로 생성되지 않습니다. 그리고 아래 두 화면에서처럼 기도 카드 모달을 fetch하는 과정에서 src/components/ui/usePrayCard.js 파일에서 정의한 checkPrayDataForToday 함수를 사용하여 미리 오늘 이미 기도했는지에 대한 조사를 통해 hasPrayed 상태변수를 관리합니다. 이는 기도 카드 모달의 하단부분의 "기도하기"를 당일 기도 여부 확인 후 미리 "기도했습니다!"로 바꿔놓고 버튼이 클릭되지 않게 하는 기능을 제공하게끔 유도됩니다.