### PR TITLE
feat: 카톡 초대 기능 구현

### DIFF
--- a/src/components/PrayDrawer.jsx
+++ b/src/components/PrayDrawer.jsx
@@ -13,14 +13,6 @@ import { useEffect } from "react";
 import { shareToKakaotalk } from "../utils";
 
 const PrayDrawer = ({ otherMembers, setPrayDone }) => {
-  useEffect(() => {
-    const script = document.createElement("script");
-    script.src = "https://developers.kakao.com/sdk/js/kakao.js";
-    script.async = true;
-    document.body.appendChild(script);
-    return () => document.body.removeChild(script);
-  }, []);
-
   return (
     <div className="flex justify-center items-center mt-20">
       <Drawer>
@@ -28,16 +20,6 @@ const PrayDrawer = ({ otherMembers, setPrayDone }) => {
           <h1 className="font-bold text-xl mb-5">오늘의 기도를 시작해보세요</h1>
           <h1>다른 그룹원들의 기도제목을</h1>
           <h1 className="mb-5">확인하고 반응해주세요</h1>
-
-          <Button
-            variant="kakao"
-            size="sm"
-            onClick={() => {
-              shareToKakaotalk();
-            }}
-          >
-            그룹 링크 공유하기
-          </Button>
 
           <DrawerTrigger>
             <div

--- a/src/components/PrayDrawer.jsx
+++ b/src/components/PrayDrawer.jsx
@@ -8,9 +8,6 @@ import {
   DrawerTrigger,
 } from "@/components/ui/drawer";
 import { PrayCarousel } from "./PrayCarousel";
-import { Button } from "./ui/button";
-import { useEffect } from "react";
-import { shareToKakaotalk } from "../utils";
 
 const PrayDrawer = ({ otherMembers, setPrayDone }) => {
   return (

--- a/src/components/PrayDrawer.jsx
+++ b/src/components/PrayDrawer.jsx
@@ -8,8 +8,19 @@ import {
   DrawerTrigger,
 } from "@/components/ui/drawer";
 import { PrayCarousel } from "./PrayCarousel";
+import { Button } from "./ui/button";
+import { useEffect } from "react";
+import { shareToKakaotalk } from "../utils";
 
 const PrayDrawer = ({ otherMembers, setPrayDone }) => {
+  useEffect(() => {
+    const script = document.createElement("script");
+    script.src = "https://developers.kakao.com/sdk/js/kakao.js";
+    script.async = true;
+    document.body.appendChild(script);
+    return () => document.body.removeChild(script);
+  }, []);
+
   return (
     <div className="flex justify-center items-center mt-20">
       <Drawer>
@@ -17,6 +28,17 @@ const PrayDrawer = ({ otherMembers, setPrayDone }) => {
           <h1 className="font-bold text-xl mb-5">오늘의 기도를 시작해보세요</h1>
           <h1>다른 그룹원들의 기도제목을</h1>
           <h1 className="mb-5">확인하고 반응해주세요</h1>
+
+          <Button
+            variant="kakao"
+            size="sm"
+            onClick={() => {
+              shareToKakaotalk();
+            }}
+          >
+            그룹 링크 공유하기
+          </Button>
+
           <DrawerTrigger>
             <div
               className="className=

--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -1,8 +1,8 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
 import { cva } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
@@ -18,6 +18,8 @@ const buttonVariants = cva(
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
+        kakao:
+          "bg-yellow-500 text-black font-bold py-2 px-4 rounded-md hover:bg-yellow-600 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:ring-opacity-50",
       },
       size: {
         default: "h-10 px-4 py-2",
@@ -31,17 +33,20 @@ const buttonVariants = cva(
       size: "default",
     },
   }
-)
+);
 
-const Button = React.forwardRef(({ className, variant, size, asChild = false, ...props }, ref) => {
-  const Comp = asChild ? Slot : "button"
-  return (
-    (<Comp
-      className={cn(buttonVariants({ variant, size, className }))}
-      ref={ref}
-      {...props} />)
-  );
-})
-Button.displayName = "Button"
+const Button = React.forwardRef(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/src/pages/GroupPage.jsx
+++ b/src/pages/GroupPage.jsx
@@ -2,15 +2,34 @@ import { useParams } from "react-router-dom";
 import useGroup from "../hooks/useGroup";
 import useAuth from "../hooks/useAuth";
 import Members from "../components/Members";
+import { Button } from "../components/ui/button";
+import { shareToKakaotalk } from "../utils";
+import { useEffect } from "react";
 
 const GroupPage = () => {
   const { user } = useAuth();
   const { groupId } = useParams();
   const { groupName } = useGroup(groupId);
+  useEffect(() => {
+    const script = document.createElement("script");
+    script.src = "https://developers.kakao.com/sdk/js/kakao.js";
+    script.async = true;
+    document.body.appendChild(script);
+    return () => document.body.removeChild(script);
+  }, []);
 
   return (
     <div>
       <h3 className="text-center mt-10 text-3xl">Group: {groupName}</h3>
+      <Button
+        variant="kakao"
+        size="sm"
+        onClick={() => {
+          shareToKakaotalk();
+        }}
+      >
+        그룹 링크 공유하기
+      </Button>
       <Members groupId={groupId} />
     </div>
   );

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,15 +13,12 @@ export const formatDateString = (dateString) => {
 };
 
 export const shareToKakaotalk = () => {
-  const key = import.meta.env.VITE_KAKAO_KEY;
-  // kakao sdk script 를 window.Kakao로 접근
+  const key = import.meta.env.VITE_KAKAO_JS_KEY;
   if (window.Kakao) {
     const kakao = window.Kakao;
 
-    // 중복 initialization 방지
-    // 카카오에서 제공하는 javascript key를 이용하여 initialize
     if (!kakao.isInitialized()) {
-      kakao.init("8cec546a8802b8b706beb1ffb28b0c8a");
+      kakao.init(key);
     }
 
     kakao.Link.sendDefault({
@@ -29,7 +26,7 @@ export const shareToKakaotalk = () => {
       content: {
         title: "PrayU",
         description: "PrayU와 함께 기도해요!",
-        imageUrl: "이미지 주소", // 온보딩 이미지 삽입
+        imageUrl: "이미지 주소",
         link: {
           mobileWebUrl: import.meta.env.VITE_BASE_URL,
           webUrl: import.meta.env.VITE_BASE_URL,

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,3 +11,30 @@ export const formatDateString = (dateString) => {
   const day = String(date.getUTCDate()).padStart(2, "0");
   return `${year}.${month}.${day}`;
 };
+
+export const shareToKakaotalk = () => {
+  const key = import.meta.env.VITE_KAKAO_KEY;
+  // kakao sdk script 를 window.Kakao로 접근
+  if (window.Kakao) {
+    const kakao = window.Kakao;
+
+    // 중복 initialization 방지
+    // 카카오에서 제공하는 javascript key를 이용하여 initialize
+    if (!kakao.isInitialized()) {
+      kakao.init("8cec546a8802b8b706beb1ffb28b0c8a");
+    }
+
+    kakao.Link.sendDefault({
+      objectType: "feed",
+      content: {
+        title: "PrayU",
+        description: "PrayU와 함께 기도해요!",
+        imageUrl: "이미지 주소", // 온보딩 이미지 삽입
+        link: {
+          mobileWebUrl: import.meta.env.VITE_BASE_URL,
+          webUrl: import.meta.env.VITE_BASE_URL,
+        },
+      },
+    });
+  }
+};


### PR DESCRIPTION
<img width="1470" alt="스크린샷 2024-07-14 오후 8 17 28" src="https://github.com/user-attachments/assets/cce3c564-8395-4fa7-942c-80aa3e226deb">

클릭하면 >>

<img width="1470" alt="스크린샷 2024-07-14 오후 8 17 32" src="https://github.com/user-attachments/assets/3a60c903-cdca-41c5-8691-14a0e3ac0c55">





카카오 초대 기능 버튼을 구현했습니다.
figma에 등록된 flow 대로 그룹 생성한 후 카톡초대버튼을 배치하고 싶었지만 현재 코드에는 그냥 GroupPage.jsx 만 있기에 일단은 PrayDrawer.jsx 컴포넌트 내에 버튼을 배치했습니다.

그리고 .env에 환경변수 비저니어 카톡계정의 자바스크립트 키로 추가해놓았습니다. 노션을 참조하시면 됩니다. 노션 링크를 남겨놓겠습니다.