### PR TITLE
refactor: useMember Auth 관련 수정

### DIFF
--- a/src/components/Members.jsx
+++ b/src/components/Members.jsx
@@ -3,28 +3,38 @@ import { ClipLoader } from "react-spinners";
 import MyProfile from "../components/MyProfile";
 import OtherProfiles from "../components/OtherProfiles";
 import PrayDrawer from "./PrayDrawer";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import PrayCard from "../components/PrayCard";
 import PrayCardCreateForm from "./PrayCardCreateForm";
 
-const Members = ({ groupId }) => {
+const Members = ({ currentUserId, groupId }) => {
   const [prayDone, setPrayDone] = useState(false);
   const {
+    loading,
     members,
-    prayCard,
+    restructedMembers,
     prayData,
     isModalOpen,
     openModal,
     closeModal,
     handleLogout,
     selectedMember,
-    loading,
-  } = useMember(groupId);
+    fetchMemberByGroupId,
+    fetchGroupPrayCards,
+  } = useMember();
 
-  const currentMember = members.find((member) => member.isCurrentUser);
-  const otherMembers = members.filter((member) => !member.isCurrentUser);
+  useEffect(() => {
+    fetchMemberByGroupId(groupId);
+  }, [fetchMemberByGroupId, groupId]);
 
-  if (loading || !currentMember) {
+  useEffect(() => {
+    if (members) {
+      const userIds = members.map((member) => member.user_id);
+      fetchGroupPrayCards(currentUserId, groupId, userIds, members);
+    }
+  }, [fetchGroupPrayCards, currentUserId, groupId, members]);
+
+  if (loading) {
     return (
       <div className="flex justify-center items-center h-screen">
         <ClipLoader size={50} color={"#123abc"} loading={true} />
@@ -32,16 +42,24 @@ const Members = ({ groupId }) => {
     );
   }
 
+  console.log("members", restructedMembers);
+  const currentMember = restructedMembers.find(
+    (member) => member.user_id === currentUserId
+  );
+  const otherMembers = restructedMembers.filter(
+    (member) => member.user_id !== currentUserId
+  );
+
   const renderModal = () =>
     selectedMember && (
       <PrayCard
         isOpen={isModalOpen}
         onClose={closeModal}
         groupId={groupId}
-        members={members}
-        selectedMember={selectedMember}
+        members={restructedMembers}
         currentMember={currentMember}
-        prayCard={prayCard}
+        selectedMember={selectedMember}
+        prayCard={selectedMember.prayCards[0]}
         prayData={prayData}
       />
     );

--- a/src/components/Members.jsx
+++ b/src/components/Members.jsx
@@ -42,7 +42,6 @@ const Members = ({ currentUserId, groupId }) => {
     );
   }
 
-  console.log("members", restructedMembers);
   const currentMember = restructedMembers.find(
     (member) => member.user_id === currentUserId
   );

--- a/src/components/PrayCard.jsx
+++ b/src/components/PrayCard.jsx
@@ -16,7 +16,6 @@ const PrayCard = ({
     isEditing,
     userInput,
     hasPrayed,
-
     handleEditClick,
     handleSaveClick,
     handleChange,
@@ -35,19 +34,19 @@ const PrayCard = ({
           <AiOutlineClose size={24} />
         </button>
         <div className="flex items-center mb-4">
-          {selectedMember.avatar_url && (
+          {selectedMember.profiles.avatar_url && (
             <img
-              src={selectedMember.avatar_url}
-              alt={`${selectedMember.full_name}'s avatar`}
+              src={selectedMember.profiles.avatar_url}
+              alt={`${selectedMember.profiles.full_name}'s avatar`}
               className="w-10 h-10 rounded-full mr-4"
             />
           )}
           <h2 className="text-xl font-bold">
-            {selectedMember.full_name}의 기도제목
+            {selectedMember.profiles.full_name}의 기도제목
           </h2>
         </div>
         <div className="flex justify-between items-center mb-4">
-          {isEditing && selectedMember.isCurrentUser ? (
+          {isEditing && selectedMember.user_id == currentMember.user_id ? (
             <textarea
               value={userInput}
               onChange={handleChange}
@@ -56,7 +55,7 @@ const PrayCard = ({
           ) : (
             <p>{userInput}</p>
           )}
-          {selectedMember.isCurrentUser &&
+          {selectedMember.user_id == currentMember.user_id &&
             (isEditing ? (
               <AiOutlineSave
                 onClick={() => handleSaveClick(groupId, prayCard)}

--- a/src/components/PrayCardCreateForm.jsx
+++ b/src/components/PrayCardCreateForm.jsx
@@ -3,8 +3,11 @@ import { Button } from "./ui/button";
 import usePrayCard from "../hooks/usePrayCard";
 
 const PrayCardCreateForm = ({ member }) => {
-  const { prayerText, setPrayerText, handleCreatePrayCard } =
-    usePrayCard(member);
+  const { prayerText, setPrayerText, handleCreatePrayCard } = usePrayCard(
+    member,
+    member.prayCards[0],
+    []
+  );
 
   return (
     <div className="flex flex-col items-center justify-start min-h-screen py-8">

--- a/src/components/PrayCardCreateForm.jsx
+++ b/src/components/PrayCardCreateForm.jsx
@@ -32,7 +32,7 @@ const PrayCardCreateForm = ({ member }) => {
       <div className="mt-4 flex flex-col items-center justify-center text-center">
         <Button
           className="bg-black hover:bg-blue-700 text-white font-bold py-2 px-4 rounded mt-4"
-          onClick={handleCreatePrayCard}
+          onClick={() => handleCreatePrayCard(member.group_id)}
         >
           저장하고 기도하러 가기
         </Button>

--- a/src/components/PrayerList.jsx
+++ b/src/components/PrayerList.jsx
@@ -1,28 +1,25 @@
 import { getDayOfWeek } from "../utils";
 
-const PrayerList = ({ members, selectedMember, currentMember, prayData }) => {
-  const prayDataWithProfile = prayData.map((pray) => ({
-    ...pray,
-    member: members.find((member) => member.user_id === pray.user_id),
-  }));
-
+const PrayerList = ({ selectedMember, currentMember, prayData }) => {
   return (
     <div className="flex bg-gray-500 text-white p-5 mt-10  gap-4">
-      {selectedMember.isCurrentUser
-        ? prayDataWithProfile.map((pray) => (
+      {selectedMember.user_id === currentMember.user_id
+        ? prayData.map((pray) => (
             <div
               key={pray.id}
               className="flex flex-col justify-center items-center gap-1"
             >
               <img
-                src={pray.member.avatar_url}
+                src={pray.profiles.avatar_url}
                 alt="avatar"
                 className="w-10 h-10 rounded-full"
               />
-              <div className="text-white text-xs">{pray.member.full_name}</div>
+              <div className="text-white text-xs">
+                {pray.profiles.full_name}
+              </div>
             </div>
           ))
-        : prayDataWithProfile
+        : prayData
             .filter((pray) => pray.user_id === currentMember.user_id)
             .map((pray) => (
               <div key={pray.id} className="text-white text-xs">

--- a/src/components/Profile.jsx
+++ b/src/components/Profile.jsx
@@ -8,11 +8,11 @@ const Profile = ({ member, onClick }) => {
     >
       <div className="flex items-center">
         <img
-          src={member.avatar_url}
-          alt={`${member.name}'s avatar`}
+          src={member.profiles.avatar_url}
+          alt={`${member.profiles.full_name}'s avatar`}
           className="w-5 h-5 rounded-full mr-4"
         />
-        <h3 className="text-white">{member.name}</h3>
+        <h3 className="text-white">{member.profiles.full_name}</h3>
       </div>
 
       <div className="text-white">

--- a/src/hooks/usePrayCard.js
+++ b/src/hooks/usePrayCard.js
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { supabase } from "../supaClient";
 
-const usePrayCard = (currentMember, lastestPrayCard, prayData) => {
+const usePrayCard = (currentMember, prayCard, prayData) => {
   const checkPrayDataForToday = (prayData, userId) => {
     const today = new Date();
     const startOfDay = new Date(today.setHours(0, 0, 0, 0));
@@ -17,11 +17,11 @@ const usePrayCard = (currentMember, lastestPrayCard, prayData) => {
     });
   };
   const [prayerText, setPrayerText] = useState(
-    lastestPrayCard ? lastestPrayCard.content : ""
+    prayCard ? prayCard.content : ""
   );
   const [isEditing, setIsEditing] = useState(false);
   const [userInput, setUserInput] = useState(
-    lastestPrayCard ? lastestPrayCard.content : "아직 기도제목이 없어요"
+    prayCard ? prayCard.content : "아직 기도제목이 없어요"
   );
   const [hasPrayed, setHasPrayed] = useState(
     checkPrayDataForToday(prayData, currentMember.user_id)
@@ -32,7 +32,7 @@ const usePrayCard = (currentMember, lastestPrayCard, prayData) => {
       alert("기도제목을 작성해주셔야 그룹원들을 위해 기도할 수 있어요");
     } else {
       await supabase.from("pray_card").insert({
-        group_id: lastestPrayCard.group_id,
+        group_id: prayCard.group_id,
         content: prayerText,
       });
       window.location.reload();
@@ -89,7 +89,6 @@ const usePrayCard = (currentMember, lastestPrayCard, prayData) => {
     isEditing,
     userInput,
     hasPrayed,
-
     handleEditClick,
     handleSaveClick,
     handleChange,

--- a/src/hooks/usePrayCard.js
+++ b/src/hooks/usePrayCard.js
@@ -27,12 +27,12 @@ const usePrayCard = (currentMember, prayCard, prayData) => {
     checkPrayDataForToday(prayData, currentMember.user_id)
   );
 
-  const handleCreatePrayCard = async () => {
+  const handleCreatePrayCard = async (groupId) => {
     if (prayerText.trim() === "") {
       alert("기도제목을 작성해주셔야 그룹원들을 위해 기도할 수 있어요");
     } else {
       await supabase.from("pray_card").insert({
-        group_id: prayCard.group_id,
+        group_id: groupId,
         content: prayerText,
       });
       window.location.reload();

--- a/src/pages/GroupPage.jsx
+++ b/src/pages/GroupPage.jsx
@@ -59,9 +59,7 @@ const GroupPage = () => {
       >
         그룹 링크 공유하기
       </Button>
-      <Members groupId={targetGroup?.id} />
-      <h3 className="text-center mt-10 text-3xl">Group: {targetGroup?.name}</h3>
-      <Members groupId={targetGroup?.id} />
+      <Members currentUserId={user.id} groupId={targetGroup?.id} />
     </div>
   );
 };


### PR DESCRIPTION
### 작업 내용

useMember 내에서 사용되고 있는 fetchSession 을 제거하고 AuthProvider 를 사용합니다.
useMember 에서 supabase 쿼리를 관리하고 컴포넌트가 렌더링될 때 useEffect 처리를 진행합니다.

### 체크리스트

- [x]  members 구조 변경
- [x]  fetchSession 제거
- [x]  useEffect, useCallback 처리
- [x]  insert member


### 테스트 

- [x] 맴버로 참여하지 않은 그룹링크 입장하여 createPrayCardForm, member 생성 확인
- [x] 맴버 fetching 확인
- [x] 맴버 클릭하여 모달 오픈 확인

### Notion
https://www.notion.so/mmyeong/refactor-Member-Auth-35a8ab7616e5498c90a4595625391711?pvs=4