### PR TITLE
chore: redirect-url hash 제거

### DIFF
--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -1,3 +1,4 @@
+import React, { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { Auth } from "@supabase/auth-ui-react";
 import { supabase } from "../supaClient";
@@ -7,13 +8,19 @@ import useAuth from "../hooks/useAuth";
 const MainPage = () => {
   const { user } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
+
   if (user) {
     navigate("/group", { replace: true });
   }
+  useEffect(() => {
+    if (location.hash) {
+      const cleanURL = `${window.location.origin}${window.location.pathname}`;
+      window.history.replaceState(null, null, cleanURL);
+    }
+  }, [location]);
 
-  const location = useLocation();
   const from = location.state?.from?.pathname || "/group";
-
   const redirectUrl = `${import.meta.env.VITE_BASE_URL}${from}`;
   return (
     <div>


### PR DESCRIPTION
배포 환경에서 redirect url에 token 값이 같이 넘어오고 있어 hash 를 제거하는 코드를 추가합니다.

![image](https://github.com/user-attachments/assets/a5375b93-c334-4174-9eda-d18229b8326a)

이런식으로 넘어옴